### PR TITLE
g-code parsing fixes & logging enhancements

### DIFF
--- a/octoprint_smartpreheat/__init__.py
+++ b/octoprint_smartpreheat/__init__.py
@@ -74,21 +74,24 @@ class SmartPreheat(octoprint.plugin.TemplatePlugin,
 
         temps = dict(tools=dict(), bed=None)
         toolNum = 0
+        lineNum = 0
+        self._logger.debug("Parsing g-code file, Path=%s", path_on_disk)
         with open(path_on_disk, "r") as file:
             for line in file:
+                lineNum += 1
 
                 if re.match(r'G1[A-Z\s]*E.*', line):
-                    self._logger.debug("Detected first extrusion. Read complete.")
+                    self._logger.debug("Line %d: Detected first extrusion. Read complete.", lineNum)
                     break
 
                 toolMatch = octoprint.util.comm.regexes_parameters["intT"].search(line)
                 if toolMatch:
-                    self._logger.debug("Detected SetTool. Line=%s" % line)
+                    self._logger.debug("Line %d: Detected SetTool. Line=%s", lineNum, line)
                     toolNum = int(toolMatch.group("value"))
 
                 match = re.match(r'M(104|109|140|190).*S.*', line)
                 if match:
-                    self._logger.debug("Detected SetTemp. Line=%s" % line)
+                    self._logger.debug("Line %d: Detected SetTemp. Line=%s", lineNum, line)
 
                     code = match.group(1)
 
@@ -97,10 +100,10 @@ class SmartPreheat(octoprint.plugin.TemplatePlugin,
                         temp = int(tempMatch.group("value"))
 
                         if code in ["104", "109"]:
-                            self._logger.debug("Tool %s = %s" % (toolNum, temp))
+                            self._logger.debug("Line %d: Tool %s = %s", lineNum, toolNum, temp)
                             temps["tools"][toolNum] = temp
                         elif code in ["140", "190"]:
-                            self._logger.debug("Bed = %s" % temp)
+                            self._logger.debug("Line %d: Bed = %s", lineNum, temp)
                             temps["bed"] = temp
 
         return temps

--- a/octoprint_smartpreheat/__init__.py
+++ b/octoprint_smartpreheat/__init__.py
@@ -105,6 +105,7 @@ class SmartPreheat(octoprint.plugin.TemplatePlugin,
                             self._logger.debug("Line %d: Bed = %s", lineNum, temp)
                             temps["bed"] = temp
 
+        self._logger.debug("Temperatures: %r", temps)
         return temps
 
     def on_event(self, event, payload):


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This basically fixes two problems that I had with the plugin:

1. Temperatures got detected incorrectly as 0 because the plugin was parsing everything through to the end of the file, instead of stopping at the first extrusion.  This occurs because Cura emits lines like  `G1 X37.944 Y45.731 E0.18608`, and the parser would only recognize G1 commands with the E parameter listed first, e.g. `G1 E0.18608 X37.944 Y45.731`.

2. The plugin would erroneously recognize any command with a T parameter as a tool-select command, including commands there the T parameter is unrelated to toolhead selection.  For example, it was setting the tool number to 500 upon reading this line:
   `M204 P500 R5000 T500 ;Setup Print/Retract/Travel acceleration`

This also makes some small improvements to debug logging.

#### How was it tested? How can it be tested by the reviewer?

- Printed on my 3D printer.  After applying these changes and updating the gcode templates in OctoPrint, temperatures were set correctly in the smartPreheat snippet.
- [Here's the gcode file](https://github.com/kantlivelong/OctoPrint-SmartPreheat/files/4568971/example.gcode.txt) that I used for testing with my printer.  I make no guarantee that it will print correctly on anyone's hardware but my own (a CR-20 running a custom version of Marlin).

#### ~~Any background context you want to provide?~~

#### ~~What are the relevant tickets if any?~~

#### ~~Screenshots (if appropriate)~~

#### ~~Further notes~~

