### PR TITLE
Fix for handling temperature G-code commands with float values

### DIFF
--- a/octoprint_smartpreheat/__init__.py
+++ b/octoprint_smartpreheat/__init__.py
@@ -97,7 +97,7 @@ class SmartPreheat(octoprint.plugin.TemplatePlugin,
 
                     tempMatch = octoprint.util.comm.regexes_parameters["floatS"].search(line)
                     if tempMatch:
-                        temp = int(tempMatch.group("value"))
+                        temp = float(tempMatch.group("value"))
 
                         if gcode in ("M104", "M109"):
                             self._logger.debug("Line %d: Tool %s = %s", lineNum, toolNum, temp)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
In my configuration, Cura is generating temperature setting G-code lines with float values like this:
`M140 S50.0`

Those work fine with Octoprint and Klipper, but seem to cause issues with SmartPreheat:
```
...
  File "X/lib/python2.7/site-packages/octoprint_smartpreheat/__init__.py", line 100, in get_temps_from_file
    temp = int(tempMatch.group("value"))
ValueError: invalid literal for int() with base 10: '50.000000'
```

Removing the fraction part from the G-code file fixes the issue, but I think SmartPreheat should also be able to handle them as well.

#### How was it tested? How can it be tested by the reviewer?
I've used it for several prints in my x86 Ubuntu/Python 2 based Octoprint+Klipper setup.
To test, modify a G-code file and add the fraction part to M104/M140/M109/M190 commands.